### PR TITLE
Added functionality for lighter loading and spatial stats summary

### DIFF
--- a/ephysiopy/common/ephys_generic.py
+++ b/ephysiopy/common/ephys_generic.py
@@ -1044,7 +1044,7 @@ class MapCalcsGeneric(object):
 			ax.spines['right'].set_visible(False)
 			ax.spines['top'].set_visible(False)
 			ax.yaxis.set_ticks_position('left')
-			ax.xaxis.set_ticks_position('bottom')		
+			ax.xaxis.set_ticks_position('bottom')
 
 	def makeSpeedVsHeadDirectionPlot(self, cluster, ax):
 		idx = self.spk_pos_idx[self.spk_clusters==cluster]

--- a/ephysiopy/common/ephys_generic.py
+++ b/ephysiopy/common/ephys_generic.py
@@ -1071,7 +1071,13 @@ class MapCalcsGeneric(object):
 		# HWPD 20200527
 		"""
 		Adds summary of various spatial metrics in a dataframe
+
+		Parameters
+		----------
+		cluster : list, numpy array
+			cell IDs to summarise (these will be recorded in the dataframe)
 		"""
+
 		import pandas as pd
 		try:
 			iter(cluster)

--- a/ephysiopy/common/ephys_generic.py
+++ b/ephysiopy/common/ephys_generic.py
@@ -1108,8 +1108,7 @@ class MapCalcsGeneric(object):
 		angles = self.hdir[self.spk_pos_idx[self.spk_clusters==cluster]]
 		r, th = S.mean_resultant_vector(np.deg2rad(angles))
 		return r, th
-	
-	
+
 	def getSpeedTuning(self, cluster, minSpeed=0.0, maxSpeed=40.0, sigma=3.0):
 		"""
 		Uses RH's speed tuning function, just returns metric and doesn't plot

--- a/ephysiopy/openephys2py/OEKiloPhy.py
+++ b/ephysiopy/openephys2py/OEKiloPhy.py
@@ -101,8 +101,7 @@ class KiloSortSession(object):
 		if os.path.exists(os.path.join(self.fname_root, 'cluster_KSLabel.tsv')):
 			self.ks_cluster_id, self.ks_group = np.loadtxt(os.path.join(self.fname_root, 'cluster_KSLabel.tsv'), unpack=True, skiprows=1, dtype=dtype)
 		self.spk_clusters = np.squeeze(np.load(os.path.join(self.fname_root, 'spike_clusters.npy')))
-		self.spk_times    = np.squeeze(np.load(os.path.join(self.fname_root, 'spike_times.npy')))
-			
+		self.spk_times    = np.squeeze(np.load(os.path.join(self.fname_root, 'spike_times.npy')))		
 
 	def removeNoiseClusters(self):
 		"""
@@ -211,7 +210,7 @@ class OpenEphysBase(object):
 		mapiter.spk_clusters = self.kilodata.spk_clusters
 		self.mapiter = mapiter
 		return mapiter
-	
+
 	def plotXCorrs(self, **kwargs):
 		if self.kilodata is None:
 			self.loadKilo()
@@ -443,7 +442,7 @@ class OpenEphysBase(object):
 		waveiter = SpkWaveform(self.kilodata.good_clusters, self.kilodata.spk_times, self.kilodata.spk_clusters, amplitudes, self.rawData)
 		for cluster in waveiter:
 			print("Cluster {}".format(cluster))
-			
+
 class OpenEphysNPX(OpenEphysBase):
 	"""The main class for dealing with data recorded using Neuropixels probes under openephys."""
 	def __init__(self, pname_root):


### PR DESCRIPTION
- OpenEphysNPX class (openephyse2py/OEKiloPhy) now has loadLite method which can load curated data without the large continuous.dat file. This now searches for spike_times.npy instead. OpenEphysNPX.ts field now ranges from recording start time to last spike time (instead of recording end time as no way to estimate this without continuous.dat).

- KilosortSession class  (openephyse2py/OEKiloPhy) load method now also loads cluster_info.tsv file. This allows us to return the spatial location of recorded cells in the brain by depth along shank, lateral electrode position and main electrode amplitude.

- MapCalsGeneric class (common/ephys_generic.py) now has several methods that allow a quick summary of spatial (grid cell) stats for each cell. The main method to use is getSpatialStats which returns a dataframe where rows are cells (IDs defined by input to the method) and labelled columns are various spatial stats.